### PR TITLE
fix: update README branding and remove non-template links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ With TestMu AI (Formerly LambdaTest), you can run Netlify integration tests acro
 
 ### Prerequisites
 
-- A [TestMu AI account](https://www.testmuai.com/register/). Retrieve your **Username** and **Access Key** from the [TestMu AI Automation Dashboard](https://automation.testmuai.com/).
-- [Node.js](https://nodejs.org/) (LTS version recommended).
-- A [Netlify](https://www.netlify.com/) account.
-- [Netlify CLI](https://docs.netlify.com/cli/get-started/) installed globally:
+- A TestMu AI account. Retrieve your **Username** and **Access Key** from the TestMu AI Automation Dashboard.
+- Node.js (LTS version recommended).
+- A Netlify account.
+- Netlify CLI installed globally:
   ```bash
   npm install -g netlify-cli
   ```


### PR DESCRIPTION
- Replace standalone LambdaTest with TestMu AI (Formerly LambdaTest) in body text\n- Remove non-template links from Prerequisites/Setup/Run tests sections